### PR TITLE
Add support for getting data via POST

### DIFF
--- a/src/Helpers/Api.php
+++ b/src/Helpers/Api.php
@@ -22,6 +22,7 @@ class Api
             if (
                 str_contains($path, '{parentId}') ||
                 str_contains($path, 'EntityInformation') ||
+                str_contains($path, 'entityInformation') ||
                 str_contains($path, 'Modules') ||
                 str_contains($path, 'ThresholdInformation') ||
                 str_contains($path, 'Version') ||

--- a/templates/Package/API/Paginator.php.twig
+++ b/templates/Package/API/Paginator.php.twig
@@ -20,19 +20,24 @@ class {{ entityName.singular }}Paginator
     /** @var PageEntity Page data transfer object. */
     protected PageEntity $page;
 
+    /** @var array Search params for POST /query request */
+    protected $postParams;
+
     /**
      * Sets up the paginator.
      *
      * @param  HttpClient  $client    Http client for retrieving pages.
      * @param  Response    $response  Response from Http client.
+     * @param  array       $postParams Search params for POST /query request
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function __construct(HttpClient $client, $response)
+    public function __construct(HttpClient $client, $response, $postParams = null)
     {
         $this->client = $client;
         $this->collection = {{ entityName.singular }}Collection::fromResponse($response);
         $this->page = PageEntity::fromResponse($response);
+        $this->postParams = $postParams;
     }
 
     /**
@@ -70,7 +75,12 @@ class {{ entityName.singular }}Paginator
      */
     public function nextPage(): {{ entityName.singular }}Paginator
     {
-        $response = $this->client->getClient()->get($this->page->nextPageUrl);
+        if(is_null($this->postParams)){
+            $response = $this->client->getClient()->get($this->page->nextPageUrl);
+        }else{
+            $response = $this->client->getClient()->post($this->page->nextPageUrl, $this->postParams);
+        }
+
         return new static($this->client, $response);
     }
 
@@ -81,7 +91,12 @@ class {{ entityName.singular }}Paginator
      */
     public function prevPage (): {{ entityName.singular }}Paginator
     {
-        $response = $this->client->getClient()->get($this->page->prevPageUrl);
+        if(is_null($this->postParams)){
+            $response = $this->client->getClient()->get($this->page->prevPageUrl);
+        }else{
+            $response = $this->client->getClient()->post($this->page->prevPageUrl, $this->postParams);
+        }
+
         return new static($this->client, $response);
     }
 }

--- a/templates/Package/API/Paginator.php.twig
+++ b/templates/Package/API/Paginator.php.twig
@@ -78,7 +78,7 @@ class {{ entityName.singular }}Paginator
         if(is_null($this->postParams)){
             $response = $this->client->getClient()->get($this->page->nextPageUrl);
         }else{
-            $response = $this->client->getClient()->post($this->page->nextPageUrl, $this->postParams);
+            $response = $this->client->getClient()->post($this->page->nextPageUrl, ['json' => $this->postParams]);
         }
 
         return new static($this->client, $response);
@@ -94,7 +94,7 @@ class {{ entityName.singular }}Paginator
         if(is_null($this->postParams)){
             $response = $this->client->getClient()->get($this->page->prevPageUrl);
         }else{
-            $response = $this->client->getClient()->post($this->page->prevPageUrl, $this->postParams);
+            $response = $this->client->getClient()->post($this->page->prevPageUrl, ['json' => $this->postParams]);
         }
 
         return new static($this->client, $response);

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -22,7 +22,7 @@ class {{ entityName.singular }}QueryBuilder
     /** @var int The maximum number of records to be returned. */
     protected int $records;
 
-    const GET_LIMIT = 1800;
+    private const GET_LIMIT = 1800;
 
     /**
      * Sets up the class to perform a query.

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -56,10 +56,6 @@ class {{ entityName.singular }}QueryBuilder
             ]);
         }
 
-         $response = $this->client->get("{{ entityName.plural }}/query/count", [
-             'search' => json_encode( $this->toArray() )
-         ]);
-
          $responseArray = json_decode($response->getBody(), true);
 
          if (! isset($responseArray['queryCount'])) {

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -23,23 +23,23 @@ class {{ entityName.singular }}QueryBuilder
     protected int $records;
 
     /** @var bool Use POST for /query requests. */
-    protected bool $usePostAsGet;
+    protected bool $usePostForQuery;
 
     /**
      * Sets up the class to perform a query.
      * 
      * @param  HttpClient  $client  The http client to execute API requests.
-     * @param  bool    $usePostAsGet     Use POST for /query requests.
+     * @param  bool    $usePostForQuery     Use POST for /query requests.
      * 
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
     public function __construct(
         HttpClient $client,
-        bool $usePostAsGet = false
+        bool $usePostForQuery = false
     )
     {
         $this->client = $client;
-        $this->usePostAsGet = $usePostAsGet;
+        $this->usePostForQuery = $usePostForQuery;
     }
 
     /**
@@ -48,7 +48,7 @@ class {{ entityName.singular }}QueryBuilder
      */
      public function count(): int
      {
-        if($this->usePostAsGet){
+        if($this->usePostForQuery){
             $response = $this->client->post("{{ entityName.plural }}/query/count", $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query/count", [
@@ -98,7 +98,7 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function get(): {{ entityName.singular }}Collection
     {
-        if($this->usePostAsGet){
+        if($this->usePostForQuery){
             $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query", [
@@ -114,7 +114,7 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function paginate(): {{ entityName.singular }}Paginator
     {
-        if($this->usePostAsGet){
+        if($this->usePostForQuery){
             $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query", [

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -25,6 +25,8 @@ class {{ entityName.singular }}QueryBuilder
     /** @var bool Use POST for /query requests. */
     protected bool $usePostForQuery;
 
+    const GET_LIMIT = 1800;
+
     /**
      * Sets up the class to perform a query.
      * 
@@ -34,12 +36,10 @@ class {{ entityName.singular }}QueryBuilder
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
     public function __construct(
-        HttpClient $client,
-        bool $usePostForQuery = false
+        HttpClient $client
     )
     {
         $this->client = $client;
-        $this->usePostForQuery = $usePostForQuery;
     }
 
     /**
@@ -48,7 +48,7 @@ class {{ entityName.singular }}QueryBuilder
      */
      public function count(): int
      {
-        if($this->usePostForQuery){
+        if (strlen($this->__toString()) >= self::GET_LIMIT) {
             $response = $this->client->post("{{ entityName.plural }}/query/count", $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query/count", [
@@ -94,7 +94,7 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function get(): {{ entityName.singular }}Collection
     {
-        if($this->usePostForQuery){
+        if (strlen($this->__toString()) >= self::GET_LIMIT) {
             $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query", [
@@ -110,15 +110,15 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function paginate(): {{ entityName.singular }}Paginator
     {
-        if($this->usePostForQuery){
+        if (strlen($this->__toString()) >= self::GET_LIMIT) {
             $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
+            return new {{ entityName.singular }}Paginator($this->client, $response, $this->toArray());
         }else{
             $response = $this->client->get("{{ entityName.plural }}/query", [
                 'search' => json_encode( $this->toArray() )
             ]);
+            return new {{ entityName.singular }}Paginator($this->client, $response);
         }
-
-        return new {{ entityName.singular }}Paginator($this->client, $response, $this->toArray());
     }
 
     /**

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -22,18 +22,24 @@ class {{ entityName.singular }}QueryBuilder
     /** @var int The maximum number of records to be returned. */
     protected int $records;
 
+    /** @var bool Use POST for /query requests. */
+    protected bool $usePostAsGet;
+
     /**
      * Sets up the class to perform a query.
      * 
      * @param  HttpClient  $client  The http client to execute API requests.
+     * @param  bool    $usePostAsGet     Use POST for /query requests.
      * 
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
     public function __construct(
-        HttpClient $client
+        HttpClient $client,
+        bool $usePostAsGet = false
     )
     {
         $this->client = $client;
+        $this->usePostAsGet = $usePostAsGet;
     }
 
     /**
@@ -42,6 +48,14 @@ class {{ entityName.singular }}QueryBuilder
      */
      public function count(): int
      {
+        if($this->usePostAsGet){
+            $response = $this->client->post("{{ entityName.plural }}/query/count", $this->toArray());
+        }else{
+            $response = $this->client->get("{{ entityName.plural }}/query/count", [
+                'search' => json_encode( $this->toArray() )
+            ]);
+        }
+
          $response = $this->client->get("{{ entityName.plural }}/query/count", [
              'search' => json_encode( $this->toArray() )
          ]);
@@ -84,9 +98,13 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function get(): {{ entityName.singular }}Collection
     {
-        $response = $this->client->get("{{ entityName.plural }}/query", [
-            'search' => json_encode( $this->toArray() )
-        ]);
+        if($this->usePostAsGet){
+            $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
+        }else{
+            $response = $this->client->get("{{ entityName.plural }}/query", [
+                'search' => json_encode( $this->toArray() )
+            ]);
+        }
 
         return {{ entityName.singular }}Collection::fromResponse($response);
     }
@@ -96,11 +114,15 @@ class {{ entityName.singular }}QueryBuilder
      */
     public function paginate(): {{ entityName.singular }}Paginator
     {
-        $response = $this->client->get("{{ entityName.plural }}/query", [
-            'search' => json_encode($this->toArray())
-        ]);
+        if($this->usePostAsGet){
+            $response = $this->client->post("{{ entityName.plural }}/query", $this->toArray());
+        }else{
+            $response = $this->client->get("{{ entityName.plural }}/query", [
+                'search' => json_encode( $this->toArray() )
+            ]);
+        }
 
-        return new {{ entityName.singular }}Paginator($this->client, $response);
+        return new {{ entityName.singular }}Paginator($this->client, $response, $this->toArray());
     }
 
     /**

--- a/templates/Package/API/QueryBuilder.php.twig
+++ b/templates/Package/API/QueryBuilder.php.twig
@@ -22,16 +22,12 @@ class {{ entityName.singular }}QueryBuilder
     /** @var int The maximum number of records to be returned. */
     protected int $records;
 
-    /** @var bool Use POST for /query requests. */
-    protected bool $usePostForQuery;
-
     const GET_LIMIT = 1800;
 
     /**
      * Sets up the class to perform a query.
      * 
      * @param  HttpClient  $client  The http client to execute API requests.
-     * @param  bool    $usePostForQuery     Use POST for /query requests.
      * 
      * @author Aidan Casey <aidan.casey@anteris.com>
      */

--- a/templates/Package/API/Service.php.twig
+++ b/templates/Package/API/Service.php.twig
@@ -22,20 +22,20 @@ class {{ entityName.singular }}Service
     protected HttpClient $client;
 
     /** @var bool Use POST for /query requests. */
-    protected bool $usePostAsGet;
+    protected bool $usePostForQuery;
 
     /**
      * Instantiates the class.
      *
      * @param  HttpClient  $client  The http client that will be used to interact with the API.
-     * @param  bool    $usePostAsGet     Use POST for /query requests.
+     * @param  bool    $usePostForQuery     Use POST for /query requests.
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function __construct(HttpClient $client, bool $usePostAsGet = false)
+    public function __construct(HttpClient $client, bool $usePostForQuery = false)
     {
         $this->client = $client;
-        $this->usePostAsGet = $usePostAsGet;
+        $this->usePostForQuery = $usePostForQuery;
     }
 {%~ if entityInformation.canCreate ~%}
     /**
@@ -153,7 +153,7 @@ class {{ entityName.singular }}Service
      */
     public function query(): {{ entityName.singular }}QueryBuilder
     {
-        return new {{ entityName.singular }}QueryBuilder($this->client, $this->usePostAsGet);
+        return new {{ entityName.singular }}QueryBuilder($this->client, $this->usePostForQuery);
     }
 {%~ endif -%}
 

--- a/templates/Package/API/Service.php.twig
+++ b/templates/Package/API/Service.php.twig
@@ -20,22 +20,16 @@ class {{ entityName.singular }}Service
 {
     /** @var Client An HTTP client for making requests to the Autotask API. */
     protected HttpClient $client;
-
-    /** @var bool Use POST for /query requests. */
-    protected bool $usePostForQuery;
-
     /**
      * Instantiates the class.
      *
      * @param  HttpClient  $client  The http client that will be used to interact with the API.
-     * @param  bool    $usePostForQuery     Use POST for /query requests.
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function __construct(HttpClient $client, bool $usePostForQuery = false)
+    public function __construct(HttpClient $client)
     {
         $this->client = $client;
-        $this->usePostForQuery = $usePostForQuery;
     }
 {%~ if entityInformation.canCreate ~%}
     /**
@@ -153,7 +147,7 @@ class {{ entityName.singular }}Service
      */
     public function query(): {{ entityName.singular }}QueryBuilder
     {
-        return new {{ entityName.singular }}QueryBuilder($this->client, $this->usePostForQuery);
+        return new {{ entityName.singular }}QueryBuilder($this->client);
     }
 {%~ endif -%}
 

--- a/templates/Package/API/Service.php.twig
+++ b/templates/Package/API/Service.php.twig
@@ -21,16 +21,21 @@ class {{ entityName.singular }}Service
     /** @var Client An HTTP client for making requests to the Autotask API. */
     protected HttpClient $client;
 
+    /** @var bool Use POST for /query requests. */
+    protected bool $usePostAsGet;
+
     /**
      * Instantiates the class.
      *
      * @param  HttpClient  $client  The http client that will be used to interact with the API.
+     * @param  bool    $usePostAsGet     Use POST for /query requests.
      *
      * @author Aidan Casey <aidan.casey@anteris.com>
      */
-    public function __construct(HttpClient $client)
+    public function __construct(HttpClient $client, bool $usePostAsGet = false)
     {
         $this->client = $client;
+        $this->usePostAsGet = $usePostAsGet;
     }
 {%~ if entityInformation.canCreate ~%}
     /**
@@ -148,7 +153,7 @@ class {{ entityName.singular }}Service
      */
     public function query(): {{ entityName.singular }}QueryBuilder
     {
-        return new {{ entityName.singular }}QueryBuilder($this->client);
+        return new {{ entityName.singular }}QueryBuilder($this->client, $this->usePostAsGet);
     }
 {%~ endif -%}
 

--- a/templates/Package/Client.php.twig
+++ b/templates/Package/Client.php.twig
@@ -14,6 +14,9 @@ class Client
     /** @var HttpClient A minimal HTTP client to be passed to each service class. */
     protected HttpClient $client;
 
+    /** @var bool Use POST for /query requests. */
+    protected bool $usePostAsGet;
+
     /**
      * Creates a new HTTP client with headers to authenticate with Autotask.
      *
@@ -21,15 +24,18 @@ class Client
      * @param  string  $secret           Autotask API user's password.
      * @param  string  $integrationCode  Autotask API user's integration code.
      * @param  string  $baseUri          Autotask API URL.
+     * @param  bool    $usePostAsGet     Use POST for /query requests.
      */
     public function __construct(
         string $username,
         string $secret,
         string $integrationCode,
-        string $baseUri
+        string $baseUri,
+        bool $usePostAsGet = false
     )
     {
         $this->client = new HttpClient($username, $secret, $integrationCode, $baseUri);
+        $this->usePostAsGet = $usePostAsGet;
     }
 {%~ for service in services|sort ~%}
     /**
@@ -38,7 +44,7 @@ class Client
     public function {{ service.plural|first|lower }}{{ service.plural|slice(1) }}(): {{ service.singular }}Service
     {
         if (! isset($this->classCache['{{ service.plural }}'])) {
-            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client);
+            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client, $this->usePostAsGet);
         }
 
         return $this->classCache['{{ service.plural }}'];

--- a/templates/Package/Client.php.twig
+++ b/templates/Package/Client.php.twig
@@ -14,9 +14,6 @@ class Client
     /** @var HttpClient A minimal HTTP client to be passed to each service class. */
     protected HttpClient $client;
 
-    /** @var bool Use POST for /query requests. */
-    protected bool $usePostForQuery;
-
     /**
      * Creates a new HTTP client with headers to authenticate with Autotask.
      *
@@ -24,18 +21,15 @@ class Client
      * @param  string  $secret           Autotask API user's password.
      * @param  string  $integrationCode  Autotask API user's integration code.
      * @param  string  $baseUri          Autotask API URL.
-     * @param  bool    $usePostForQuery     Use POST for /query requests.
      */
     public function __construct(
         string $username,
         string $secret,
         string $integrationCode,
-        string $baseUri,
-        bool $usePostForQuery = false
+        string $baseUri
     )
     {
         $this->client = new HttpClient($username, $secret, $integrationCode, $baseUri);
-        $this->usePostForQuery = $usePostForQuery;
     }
 {%~ for service in services|sort ~%}
     /**
@@ -44,7 +38,7 @@ class Client
     public function {{ service.plural|first|lower }}{{ service.plural|slice(1) }}(): {{ service.singular }}Service
     {
         if (! isset($this->classCache['{{ service.plural }}'])) {
-            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client, $this->usePostForQuery);
+            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client);
         }
 
         return $this->classCache['{{ service.plural }}'];

--- a/templates/Package/Client.php.twig
+++ b/templates/Package/Client.php.twig
@@ -15,7 +15,7 @@ class Client
     protected HttpClient $client;
 
     /** @var bool Use POST for /query requests. */
-    protected bool $usePostAsGet;
+    protected bool $usePostForQuery;
 
     /**
      * Creates a new HTTP client with headers to authenticate with Autotask.
@@ -24,18 +24,18 @@ class Client
      * @param  string  $secret           Autotask API user's password.
      * @param  string  $integrationCode  Autotask API user's integration code.
      * @param  string  $baseUri          Autotask API URL.
-     * @param  bool    $usePostAsGet     Use POST for /query requests.
+     * @param  bool    $usePostForQuery     Use POST for /query requests.
      */
     public function __construct(
         string $username,
         string $secret,
         string $integrationCode,
         string $baseUri,
-        bool $usePostAsGet = false
+        bool $usePostForQuery = false
     )
     {
         $this->client = new HttpClient($username, $secret, $integrationCode, $baseUri);
-        $this->usePostAsGet = $usePostAsGet;
+        $this->usePostForQuery = $usePostForQuery;
     }
 {%~ for service in services|sort ~%}
     /**
@@ -44,7 +44,7 @@ class Client
     public function {{ service.plural|first|lower }}{{ service.plural|slice(1) }}(): {{ service.singular }}Service
     {
         if (! isset($this->classCache['{{ service.plural }}'])) {
-            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client, $this->usePostAsGet);
+            $this->classCache['{{ service.plural }}'] = new {{ service.singular }}Service($this->client, $this->usePostForQuery);
         }
 
         return $this->classCache['{{ service.plural }}'];


### PR DESCRIPTION
The pull request adds support for getting data via POST including count queries and pagination.

The setting could be turned on at a client level in order to update apps without changing the code:

```php
$client = new Anteris\Autotask\Client($apiUser, $apiSecret, $integrationCode, $baseUrl, true);
```

Or it can be done per service:

```php
$contactEndpoint = new Anteris\Autotask\API\Contacts\ContactService($client, true);
```

Fixes https://github.com/Anteris-Dev/autotask-client-generator/issues/14